### PR TITLE
Views für den Zentralen Display überarbeitet:

### DIFF
--- a/public/css/style.css
+++ b/public/css/style.css
@@ -1,8 +1,88 @@
-#track-wrapper {
-    height: 25%;
-    width: 33%;
+/* ##### General ##### */
+* {}
 
-    float: left;
+/* ##### Streckenmodus #####*/
+.strecken-panel{
+    margin-left:1.5%;
+    margin-right:1.5%;
+    min-width: 250px;
+    width: 30%;
+}
+
+/* ##### Leistung im Leistungs- oder Drehmoment-Modi #####*/
+.leistung-panel{
+    margin-left:1.5%;
+    margin-right:1.5%;
+    min-width: 250px;
+    width: 30%;
+}
+
+/* ##### Gesamtleistung #####*/
+.gesamtleistung-panel{
+    margin-left:1.5%;
+    margin-right:1.5%;
+    min-width: 250px;
+    width: 30%;
+}
+
+/* ##### Fahrradinformationen #####*/
+.fahrrad-information-panel{
+    margin-left:1.5%;
+    margin-right:1.5%;
+    min-width: 250px;
+    width: 30%;
+}
+
+/* ##### Tagesstatistik #####*/
+.tagesstatistik-panel{
+    margin-left:1.5%;
+    margin-right:1.5%;
+    min-width: 250px;
+    width: 50%;
+}
+
+/* ##### Batterie #####*/
+.batterie-panel{
+    margin-left:1.5%;
+    margin-right:1.5%;
+    min-width: 250px;
+    width: 20%;
+}
+
+
+/* ##### Logout ##### */
+#btnLogout{
+    height: 50px;
+    margin-top: 25px;
+    width: 100%;
+}
+
+#logout-wrapper {
+    bottom: 0;
+    left: 0;
+    position: absolute;
+    width: 100%;
+}
+
+/* ##### Misc ##### */
+.clear{
+    clear: both;
+}
+
+/* ##### Mobile ##### */
+#fahrrad-information-wrapper-mobile{
+    height: 25%;
+}
+
+.fahrrad-wrapper-mobile{
+    background-color: ghostwhite;
+    color: #000;
+    height: 25%;
+    margin-top: 50px;
+    margin-left: 2%;
+    padding: 10px;
+    text-align: center;
+    width: 100%;
 }
 
 #track-wrapper-mobile {
@@ -10,71 +90,4 @@
     width: 100%;
 }
 
-#energy-current-wrapper {
-    height: 25%;
-    width: 33%;
 
-    float: left;
-}
-
-#energy-wrapper {
-    height: 25%;
-    width: 33%;
-
-    float: left;
-}
-
-#fahrrad-information-wrapper{
-    height: 25%;
-}
-
-#fahrrad-information-wrapper-mobile{
-    height: 25%;
-}
-
-.fahrrad-wrapper{
-    height: 25%;
-    width: 30%;
-
-    border: 5px solid blue;
-    border-radius: 5px;
-    background-color: ghostwhite;
-    color: #000;
-    text-align: center;
-    padding: 10px;
-
-    margin-top: 50px;
-    margin-left: 2%;
-
-    float:left;
-}
-
-.fahrrad-wrapper-mobile{
-    height: 25%;
-    width: 100%;
-
-    background-color: ghostwhite;
-    color: #000;
-    text-align: center;
-    padding: 10px;
-
-    margin-top: 50px;
-    margin-left: 2%;
-}
-
-#logout-wrapper {
-    width: 100%;
-    position: absolute;
-    bottom: 0;
-    left: 0;
-}
-
-#btnLogout{
-    margin-top: 25px;
-    width: 100%;
-    height: 50px;
-}
-
-.clear {
-    clear: both;
-}

--- a/resources/views/central/batterieladung.blade.php
+++ b/resources/views/central/batterieladung.blade.php
@@ -1,0 +1,8 @@
+<div class="panel panel-default pull-left batterie-panel ">
+    <div class="panel-heading">
+        <h3 class="panel-title">Batterie</h3>
+    </div>
+    <div class="panel-body">
+
+    </div>
+</div>

--- a/resources/views/central/fahrrad-information.blade.php
+++ b/resources/views/central/fahrrad-information.blade.php
@@ -1,38 +1,47 @@
-<div id="fahrrad-information-wrapper">
+<div class ="container-fluid">
     @foreach($fahrraeder as $fahrrad)
-        <div class="fahrrad-wrapper" id="{{ $fahrrad->id }}">
-            <h1>Fahrrad #{{ $fahrrad->id }}</h1>
-            <h2>Fahrer: {{ $fahrrad->getFahrerName() }}</h2>
-            <div class="row">
-                <div class="col-md-6">Geschwindigkeit</div>
-                <div id="geschwindigkeit-anzeige-{{ $fahrrad->id }}" class="col-md-6">{{ $fahrrad->geschwindigkeit }} km/h</div>
+        <div class="panel panel-default pull-left fahrrad-information-panel">
+            <div class="panel-heading" id="{{ $fahrrad->id }}">
+                <h3 class="panel-title">Fahrrad #{{ $fahrrad->id }}</h3>
             </div>
-            <div class="row">
-                <div class="col-md-6">istLeistung</div>
-                <div id="istLeistung-anzeige-{{ $fahrrad->id }}" class="col-md-6">{{ $fahrrad->istLeistung }}</div>
-            </div>
-            <div class="row">
-                <div class="col-md-6">Zurückgelegte Strecke</div>
-                <div id="strecke-anzeige-{{ $fahrrad->id }}" class="col-md-6">{{ $fahrrad->strecke }} m</div>
-            </div>
-            <hr>
-            <div class="row">
-                <div class="col-md-6">sollLeistung</div>
-                <div id="sollLeistung-anzeige-{{ $fahrrad->id }}" class="col-md-6">{{ $fahrrad->sollLeistung }}</div>
-            </div>
-            <div class="row">
-                <div class="col-md-6">sollDrehmoment</div>
-                <div id="sollDrehmoment-anzeige-{{ $fahrrad->id }}" class="col-md-6">{{ $fahrrad->sollDrehmoment }}</div>
-            </div>
-            <div class="row">
-                <div class="col-md-6">strecke_id</div>
-                <div id="strecke_id-anzeige-{{ $fahrrad->id }}" class="col-md-6">{{ $fahrrad->strecke_id }}</div>
-            </div>
-            <div class="row">
-                <div class="col-md-6">abschnitt_id</div>
-                <div id="abschnitt_id-anzeige-{{ $fahrrad->id }}" class="col-md-6">{{ $fahrrad->abschnitt_id }}</div>
+            <div class="panel-body ">
+                    <div class="row">
+                        <div class="col-lg-6">Fahrer:</div>
+                        <div id="fahrername-anzeige-{{ $fahrrad->id }}" class="col-lg-6">{{ $fahrrad->getFahrerName() }}</div>
+                    </div>
+
+                    <div class="row">
+                        <div class="col-lg-6 ">Geschwindigkeit</div>
+                        <div id="geschwindigkeit-anzeige-{{ $fahrrad->id }}" class="col-lg-6">{{ $fahrrad->geschwindigkeit }} km/h</div>
+                    </div>
+                    <div class="row">
+                        <div class="col-lg-6">istLeistung</div>
+                        <div id="istLeistung-anzeige-{{ $fahrrad->id }}" class="col-lg-6">{{ $fahrrad->istLeistung }}</div>
+                    </div>
+                    <div class="row">
+                        <div class="col-lg-6">Zurückgelegte Strecke</div>
+                        <div id="strecke-anzeige-{{ $fahrrad->id }}" class="col-lg-6">{{ $fahrrad->strecke }} m</div>
+                    </div>
+                    <hr>
+                    <div class="row">
+                        <div class="col-lg-6">sollLeistung</div>
+                        <div id="sollLeistung-anzeige-{{ $fahrrad->id }}" class="col-lg-6">{{ $fahrrad->sollLeistung }}</div>
+                    </div>
+                    <div class="row">
+                        <div class="col-lg-6">sollDrehmoment</div>
+                        <div id="sollDrehmoment-anzeige-{{ $fahrrad->id }}" class="col-lg-6">{{ $fahrrad->sollDrehmoment }}</div>
+                    </div>
+                    <div class="row">
+                        <div class="col-lg-6">strecke_id</div>
+                        <div id="strecke_id-anzeige-{{ $fahrrad->id }}" class="col-lg-6">{{ $fahrrad->strecke_id }}</div>
+                    </div>
+                    <div class="row">
+                        <div class="col-lg-6">abschnitt_id</div>
+                        <div id="abschnitt_id-anzeige-{{ $fahrrad->id }}" class="col-lg-6">{{ $fahrrad->abschnitt_id }}</div>
+                    </div>
             </div>
         </div>
+
     @endforeach
     <div class="clear"></div>
 </div>

--- a/resources/views/central/highscore.blade.php
+++ b/resources/views/central/highscore.blade.php
@@ -1,0 +1,16 @@
+<div class="panel panel-default pull-left highscore-panel">
+    <div class="panel-heading">
+        <h3 class="panel-title">Highscore</h3>
+    </div>
+    <div class="panel-body">
+        <div class="row">
+            <div class="col-lg-12">Platz 1:</div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12">Platz 2:</div>
+        </div>
+        <div class="row">
+            <div class="col-lg-12">Platz 3:</div>
+        </div>
+    </div>
+</div>

--- a/resources/views/central/index.blade.php
+++ b/resources/views/central/index.blade.php
@@ -1,19 +1,62 @@
 @extends("layouts.app")
 
 @section("content")
-    <div id="track-wrapper">
-        <canvas id="track"></canvas>
+
+    <div class ="container-fluid">
+        {{-- Anzeige Streckenmodus  --}}
+        <div class="panel panel-default pull-left strecken-panel">
+            <div class="panel-heading">
+                <h3 class="panel-title">Streckenmodus</h3>
+            </div>
+            <div class="panel-body">
+                <div id="track-wrapper col-lg-12">
+                    <canvas id="track"></canvas>
+                </div>
+            </div>
+        </div>
+
+        {{-- Anzeige der Leistung im Modus konstante Leistung und konstanter Drehmoment --}}
+        <div class="panel panel-default pull-left leistung-panel">
+            <div class="panel-heading">
+                <h3 class="panel-title">Leistung</h3>
+            </div>
+            <div class="panel-body">
+                <div id="energy-current-wrapper col-lg-12">
+                    <canvas id="energy-current"></canvas>
+                </div>
+            </div>
+        </div>
+
+        {{-- Anzeige Gesamtenergie  --}}
+        <div class="panel panel-default pull-left gesamtleistung-panel">
+            <div class="panel-heading">
+                <h3 class="panel-title">Gesamtleistung</h3>
+            </div>
+            <div class="panel-body">
+                <div id="energy-wrapper col-lg-12">
+                    <canvas id="energy"></canvas>
+                </div>
+            </div>
+        </div>
+
+        <div class="clear"></div>
     </div>
 
-    <div id="energy-current-wrapper">
-        <canvas id="energy-current"></canvas>
-    </div>
 
-    <div id="energy-wrapper">
-        <canvas id="energy"></canvas>
-    </div>
 
-    <div class="clear"></div>
-
+    {{-- Anzeige der Fahrerdetails  --}}
     @include("central.fahrrad-information")
+
+    <div class ="container-fluid">
+        {{-- Anzeige der Tagesstatistik --}}
+        @include("central.tagesstatistik")
+        {{-- Anzeige der Highscore  --}}
+        @include("central.highscore")
+        {{-- Anzeige der Batterieladung  --}}
+        @include("central.batterieladung")
+        <div class="clear"></div>
+    </div>
+
 @endsection
+
+

--- a/resources/views/central/tagesstatistik.blade.php
+++ b/resources/views/central/tagesstatistik.blade.php
@@ -1,0 +1,13 @@
+<div class="panel panel-default pull-left tagesstatistik-panel">
+    <div class="panel-heading">
+        <h3 class="panel-title">Tagesstatistik</h3>
+    </div>
+    <div class="panel-body">
+        <div class="row">
+            <div class="col-lg-3">Teilnehmer:</div>
+            <div class="col-lg-3">Kilometer:</div>
+            <div class="col-lg-3">Höhenprofil:</div>
+            <div class="col-lg-3">Energie:</div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
- fehlende Elemente erweitert (Tagesstatistik, Highscore, Batterie)
- alle Elemente neu angeordnet und damit alles einheitlicher wird Wrapper durch Panels ersetzt und Graphen ebenfalls mit Panels "umrahmt"
- Style.css wurde dementsprechend verändert und per Kommentare in inhaltliche Bereiche gegliedert, Eigenschaften alphabetisch sortiert